### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/methods_per_port.py
+++ b/examples/methods_per_port.py
@@ -82,7 +82,7 @@ class MsgHandler(object):
             return True
 
         self._methods.add(msg.method)
-        print('On port %d, method %s was called' % (self._port, msg.method))
+        print('On port {0:d}, method {1!s} was called'.format(self._port, msg.method))
 
         return True  # must return true, or sniffer will exit
 

--- a/thrift_tools/file_reader.py
+++ b/thrift_tools/file_reader.py
@@ -45,8 +45,8 @@ def get_flags():
                    '(long) + the message length (int), the padding would be of '
                    '12 bytes')
     p.add_argument('--protocol', type=str, default='binary',
-                   help='Use a specific protocol for reading structs. Options: %s' %
-                   VALID_PROTOCOLS)
+                   help='Use a specific protocol for reading structs. Options: {0!s}'.format(
+                   VALID_PROTOCOLS))
     p.add_argument('--debug', default=False, action='store_true',
                    help='Display debugging messages')
 
@@ -69,8 +69,8 @@ def run(flags, output=sys.stdout):
             elif flags.protocol == 'json':
                 protocol = TJSONProtocol
             else:
-                output.write('Unknown protocol: %s' % flags.protocol)
-                output.write('Valid options for --protocol are: %s' % VALID_PROTOCOLS)
+                output.write('Unknown protocol: {0!s}'.format(flags.protocol))
+                output.write('Valid options for --protocol are: {0!s}'.format(VALID_PROTOCOLS))
                 sys.exit(1)
 
             thrift_file = ThriftStructFile(
@@ -109,9 +109,9 @@ def run(flags, output=sys.stdout):
 
     what = 'structs' if flags.structs else 'msgs'
     if holes:
-        output.write('Read %s: %d\nHoles: %d\n' % (what, total_msg_read, len(holes)))
+        output.write('Read {0!s}: {1:d}\nHoles: {2:d}\n'.format(what, total_msg_read, len(holes)))
         if flags.show_holes:
             for idx, hole in enumerate(holes, start=1):
-                output.write('#%d: start=%d, size=%d' % (idx, hole[0], hole[1]))
+                output.write('#{0:d}: start={1:d}, size={2:d}'.format(idx, hole[0], hole[1]))
     else:
-        output.write('Read %s: %d\nNo bytes skipped' % (what, total_msg_read))
+        output.write('Read {0!s}: {1:d}\nNo bytes skipped'.format(what, total_msg_read))

--- a/thrift_tools/message_sniffer.py
+++ b/thrift_tools/message_sniffer.py
@@ -55,16 +55,16 @@ class MessageSniffer(Thread):
 
     def status(self):
         return """
-alive:                  %s
-queue size:             %d
-seen streams:           %d
-unrecognized streams:   %d
-seen thrift msgs:       %d
-pending thrift msgs:    %d
-sniffer alive:          %s
-pending ip packets:     %d
-dispatcher alive:       %s
-""" % (self.isAlive(),
+alive:                  {0!s}
+queue size:             {1:d}
+seen streams:           {2:d}
+unrecognized streams:   {3:d}
+seen thrift msgs:       {4:d}
+pending thrift msgs:    {5:d}
+sniffer alive:          {6!s}
+pending ip packets:     {7:d}
+dispatcher alive:       {8!s}
+""".format(self.isAlive(),
        len(self._queue),
        self._handler.seen_streams,
        self._handler.unrecognized_streams,
@@ -114,11 +114,11 @@ dispatcher alive:       %s
                         running = False
                         break
                 except Exception as ex:
-                    print('handler exception: %s' % ex)
+                    print('handler exception: {0!s}'.format(ex))
 
         # leaving...
         if len(self._queue):
-            print('%d messages left in the queue' % len(self._queue))
+            print('{0:d} messages left in the queue'.format(len(self._queue)))
 
     def stop(self, wait_for_stopped=False):
         if not self.isAlive():

--- a/thrift_tools/printer.py
+++ b/thrift_tools/printer.py
@@ -45,12 +45,12 @@ def print_msg(timestamp, src, dst, msg, format_opts,
     indent = ' ' * indent if indent else ''
 
     if format_opts.show_header:
-        header_line = '%sheader: %s\n' % (indent, pretty(msg.header))
+        header_line = '{0!s}header: {1!s}\n'.format(indent, pretty(msg.header))
     else:
         header_line = ''
 
     if format_opts.show_fields:
-        fields_line = '%sfields: %s\n' % (indent, pretty(msg.args))
+        fields_line = '{0!s}fields: {1!s}\n'.format(indent, pretty(msg.args))
     else:
         fields_line = ''
 
@@ -72,7 +72,7 @@ def print_msg(timestamp, src, dst, msg, format_opts,
 
         outputstr = json.dumps(parts, indent=4) + '\n'
     else:
-        outputstr = '%s[%s] %s -> %s: method=%s, type=%s, seqid=%d\n%s%s' % (
+        outputstr = '{0!s}[{1!s}] {2!s} -> {3!s}: method={4!s}, type={5!s}, seqid={6:d}\n{7!s}{8!s}'.format(
             prefix, timestr, src, dst, msg.method, msg.type, msg.seqid,
             header_line, fields_line)
 
@@ -186,7 +186,7 @@ class LatencyPrinter(object):
                 self._seen += 1
 
                 # let the user know we are still working
-                self._output.write('\rCollecting (%d/%d)' % (
+                self._output.write('\rCollecting ({0:d}/{1:d})'.format(
                         self._seen, self._expected))
                 self._output.flush()
 
@@ -202,7 +202,7 @@ class LatencyPrinter(object):
                 unmatched += len(calls)
 
         if unmatched > 0:
-            self._output.write('%d unmatched calls\n' % unmatched)
+            self._output.write('{0:d} unmatched calls\n'.format(unmatched))
 
         return False  # we are done
 
@@ -235,5 +235,5 @@ class LatencyPrinter(object):
 
         data = [row(key, result) for key, result in results]
 
-        self._output.write('%s\n' % tabulate(data, headers=headers))
+        self._output.write('{0!s}\n'.format(tabulate(data, headers=headers)))
         self._output.flush()

--- a/thrift_tools/sniffer.py
+++ b/thrift_tools/sniffer.py
@@ -29,7 +29,7 @@ class Stream(object):
         self._lock_packets = Lock()
 
     def __str__(self):
-        return '%s<->%s (length: %d, remaining: %d, seq_id: %d)' % (
+        return '{0!s}<->{1!s} (length: {2:d}, remaining: {3:d}, seq_id: {4:d})'.format(
             self.src, self.dst, self.length, self.remaining, self._next_seq_id)
 
     @property
@@ -132,9 +132,9 @@ class Dispatcher(Thread):
                 src_ip = get_ip(ip_p, ip_p.src)
                 dst_ip = get_ip(ip_p, ip_p.dst)
 
-                src = intern('%s:%s' % (src_ip, ip_p.data.sport))
-                dst = intern('%s:%s' % (dst_ip, ip_p.data.dport))
-                key = intern('%s<->%s' % (src, dst))
+                src = intern('{0!s}:{1!s}'.format(src_ip, ip_p.data.sport))
+                dst = intern('{0!s}:{1!s}'.format(dst_ip, ip_p.data.dport))
+                key = intern('{0!s}<->{1!s}'.format(src, dst))
 
                 stream = self._streams.get(key)
                 if stream is None:
@@ -153,7 +153,7 @@ class Dispatcher(Thread):
                     try:
                         handler(stream)
                     except Exception as ex:
-                        print('handler exception: %s' % ex)
+                        print('handler exception: {0!s}'.format(ex))
             except Exception:
                 time.sleep(0.00001)
 
@@ -199,7 +199,7 @@ class Sniffer(Thread):
         self._dispatcher.add_handler(stream_handler)
 
     def run(self):
-        pfilter = 'port %d' % self._port
+        pfilter = 'port {0:d}'.format(self._port)
         try:
             kwargs = {
                 'filter': pfilter,
@@ -215,9 +215,9 @@ class Sniffer(Thread):
             sniff(**kwargs)
         except Exception as ex:
             if 'Not a pcap capture file' in str(ex):
-                print('%s is not a valid pcap file' % self._offline)
+                print('{0!s} is not a valid pcap file'.format(self._offline))
                 return
-            print('Error: %s: %s (device: %s)' % (ex, traceback.format_exc(), self._iface))
+            print('Error: {0!s}: {1!s} (device: {2!s})'.format(ex, traceback.format_exc(), self._iface))
         finally:
             if self._offline:
                 # drain dispatcher

--- a/thrift_tools/stream_handler.py
+++ b/thrift_tools/stream_handler.py
@@ -65,7 +65,7 @@ class StreamHandler(object):
         # EMSGSIZE
         if len(context.bytes) >= self._max_message_size:
             if self._debug:
-                print('Dropping bytes, dropped size: %d' % len(context.bytes))
+                print('Dropping bytes, dropped size: {0:d}'.format(len(context.bytes)))
             context.bytes = ''
             return
 

--- a/thrift_tools/tests/test_basic.py
+++ b/thrift_tools/tests/test_basic.py
@@ -73,7 +73,7 @@ class BasicTestCase(unittest.TestCase):
 
     def _test_protocol(self, protoname):
         queue = deque()
-        pcap_file = get_pcap_path('calc-service-%s' % protoname)
+        pcap_file = get_pcap_path('calc-service-{0!s}'.format(protoname))
         handler = StreamHandler(queue, read_values=True, debug=True)
 
         sniffer = Sniffer('ignore', 9090, handler, offline=pcap_file)

--- a/thrift_tools/tests/util.py
+++ b/thrift_tools/tests/util.py
@@ -7,8 +7,8 @@ _resources_dir = os.path.join(
 
 
 def get_pcap_path(capture_file):
-    return os.path.join(_resources_dir, '%s.pcap' % (capture_file))
+    return os.path.join(_resources_dir, '{0!s}.pcap'.format((capture_file)))
 
 
 def get_log_path(log_file):
-    return os.path.join(_resources_dir, '%s.logfile' % (log_file))
+    return os.path.join(_resources_dir, '{0!s}.logfile'.format((log_file)))

--- a/thrift_tools/thrift_file.py
+++ b/thrift_tools/thrift_file.py
@@ -39,7 +39,7 @@ class ThriftFile(object):
             try:
                 fh = open(file_name)
             except IOError as ex:
-                raise ThriftFile.Error('Could not open %s: %s' % (file_name, ex))
+                raise ThriftFile.Error('Could not open {0!s}: {1!s}'.format(file_name, ex))
 
         if HAS_MMAP and file_name != '-':
             self._data = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
@@ -99,7 +99,7 @@ class ThriftMessageFile(ThriftFile):
                 return (msg, None) if skipped == 0 else (msg, (start, skipped))
             except Exception, ex:
                 if self._debug:
-                    print('Bad message: %s (idx=%d)' % (ex, idx))
+                    print('Bad message: {0!s} (idx={1:d})'.format(ex, idx))
 
         # nothing found
         return (None, None)
@@ -142,7 +142,7 @@ class ThriftStructFile(ThriftFile):
                 return (tstruct, None) if skipped == 0 else (tstruct, (start, skipped))
             except Exception, ex:
                 if self._debug:
-                    print('Bad message: %s (idx=%d)' % (ex, idx))
+                    print('Bad message: {0!s} (idx={1:d})'.format(ex, idx))
 
         # nothing found
         return (None, None)

--- a/thrift_tools/thrift_message.py
+++ b/thrift_tools/thrift_message.py
@@ -52,7 +52,7 @@ class ThriftMessage(object):
         return self._header
 
     def __str__(self):
-        return 'method=%s, type=%s, seqid=%s, header=%s, fields=%s' % (
+        return 'method={0!s}, type={1!s}, seqid={2!s}, header={3!s}, fields={4!s}'.format(
             self.method, self.type, self.seqid, self.header, str(self.args))
 
     @property
@@ -131,7 +131,7 @@ class ThriftMessage(object):
         # suspicious method names
         valid = range(33, 127)
         if any(ord(char) not in valid for char in method):
-            raise ValueError('invalid method name' % method)
+            raise ValueError('invalid method name'.format(*method))
 
         args = ThriftStruct.read(
             proto,
@@ -198,4 +198,4 @@ class ThriftMessage(object):
         elif mtype == TMessageType.ONEWAY:
             return 'oneway'
         else:
-            raise ValueError('Unknown message type: %s' % mtype)
+            raise ValueError('Unknown message type: {0!s}'.format(mtype))

--- a/thrift_tools/thrift_struct.py
+++ b/thrift_tools/thrift_struct.py
@@ -57,7 +57,7 @@ class ThriftStruct(object):
         return iter(self._fields)
 
     def __repr__(self):
-        return "fields=%s" % self.fields
+        return "fields={0!s}".format(self.fields)
 
     @classmethod
     def read(cls,
@@ -76,7 +76,7 @@ class ThriftStruct(object):
         while True:
             nfields += 1
             if nfields >= max_fields:
-                raise ObjectTooBig('too many fields: %d' % nfields)
+                raise ObjectTooBig('too many fields: {0:d}'.format(nfields))
 
             _, ftype, fid = proto.readFieldBegin()
             if ftype == TType.STOP:
@@ -159,7 +159,7 @@ class ThriftStruct(object):
         elif ftype == TType.LIST:
             (etype, size) = proto.readListBegin()
             if size > max_list_size:
-                raise ObjectTooBig('list too long: %d' % size)
+                raise ObjectTooBig('list too long: {0:d}'.format(size))
             value = []
             if read_values:
                 value = [_read(etype) for _ in xrange(size)]
@@ -170,7 +170,7 @@ class ThriftStruct(object):
         elif ftype == TType.MAP:
             (ktype, vtype, size) = proto.readMapBegin()
             if size > max_map_size:
-                raise ObjectTooBig('map too big: %d' % size)
+                raise ObjectTooBig('map too big: {0:d}'.format(size))
             value = {}
             if read_values:
                 for i in xrange(size):
@@ -185,7 +185,7 @@ class ThriftStruct(object):
         elif ftype == TType.SET:
             (etype, size) = proto.readSetBegin()
             if size > max_set_size:
-                raise ObjectTooBig('set too big: %d' % size)
+                raise ObjectTooBig('set too big: {0:d}'.format(size))
             value = set()
             if read_values:
                 for i in xrange(size):
@@ -237,7 +237,7 @@ class ThriftStruct(object):
         elif ftype == TType.UTF16:
             return 'utf16'
         else:
-            raise ValueError('Unknown type: %s' % ftype)
+            raise ValueError('Unknown type: {0!s}'.format(ftype))
 
 
 class ThriftField(object):
@@ -256,7 +256,7 @@ class ThriftField(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return '(%s, %s, %s)' % (
+        return '({0!s}, {1!s}, {2!s})'.format(
             self.field_type, self.field_id, self._value)
 
     def is_isomorphic_to(self, other):

--- a/thrift_tools/tool.py
+++ b/thrift_tools/tool.py
@@ -41,8 +41,8 @@ def get_flags():
     p.add_argument('--debug', default=False, action='store_true',
                    help='Display debugging messages')
     p.add_argument('--protocol', type=str, default='auto',
-                   help='Use a specific protocol. Options: %s' %
-                   VALID_PROTOCOLS)
+                   help='Use a specific protocol. Options: {0!s}'.format(
+                   VALID_PROTOCOLS))
 
     cmds = p.add_subparsers(dest='cmd')
 
@@ -96,7 +96,7 @@ def main():
         printer = printer_cls(format_opts)
         read_values = flags.show_values or flags.show_all
     else:
-        print('Unknown command: %s' % flags.cmd)
+        print('Unknown command: {0!s}'.format(flags.cmd))
         sys.exit(1)
 
     # which protocol to use
@@ -109,8 +109,8 @@ def main():
     elif flags.protocol == 'json':
         protocol = TJSONProtocol
     else:
-        print('Unknown protocol: %s' % flags.protocol)
-        print('Valid options for --protocol are: %s' % VALID_PROTOCOLS)
+        print('Unknown protocol: {0!s}'.format(flags.protocol))
+        print('Valid options for --protocol are: {0!s}'.format(VALID_PROTOCOLS))
         sys.exit(1)
 
     # launch the thrift message sniffer
@@ -129,7 +129,7 @@ def main():
     message_sniffer = MessageSniffer(options, printer)
 
     def sigusr_handler(*args):
-        print('message sniffer status: %s' % message_sniffer.status(),
+        print('message sniffer status: {0!s}'.format(message_sniffer.status()),
               file=sys.stderr)
 
     # wire up sigusr1 for debugging info

--- a/thrift_tools/util.py
+++ b/thrift_tools/util.py
@@ -38,7 +38,7 @@ def get_ip_packet(data, client_port, server_port, is_loopback=False):
     try:
         header.unpack(data)
     except Exception as ex:
-        raise ValueError('Bad header: %s' % ex)
+        raise ValueError('Bad header: {0!s}'.format(ex))
 
     tcp_p = getattr(header.data, 'data', None)
     if type(tcp_p) != dpkt.tcp.TCP:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:thrift-tools?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:thrift-tools?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
